### PR TITLE
support specialfunctions 2.x

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ Distributions = "0.20, 0.21, 0.22, 0.23, 0.24"
 QuadGK = "2"
 RecipesBase = "1"
 Roots = "1"
-SpecialFunctions = "1"
+SpecialFunctions = "1, 2"
 StatsBase = "0.30, 0.31, 0.32, 0.33"
 julia = "1"
 


### PR DESCRIPTION
The only breaking change in SpecialFunctions 2.0 [was deleting](https://github.com/JuliaMath/SpecialFunctions.jl/pull/297) the `factorial(x::Real) = gamma(x)` function, and since you don't use `factorial` this shouldn't affect you.